### PR TITLE
Typo in tutorial docs

### DIFF
--- a/tutorial/server.md
+++ b/tutorial/server.md
@@ -316,7 +316,7 @@ that get turned into arguments to the handlers, the type of the argument.
 
 > - `Delete`, `Get`, `Patch`, `Post`, `Put`: these do not become arguments. They provide the return type of handlers, which usually is `EitherT ServantErr IO <something>`.
 > - `Capture "something" a` becomes an argument of type `a`.
-> - `QueryParam "something" a`, `MatrixParam "something" a`, `Header "something" a` both become an argument of type `Maybe a`, because there might be no value at all specified by the client for these.
+> - `QueryParam "something" a`, `MatrixParam "something" a`, `Header "something" a` all become arguments of type `Maybe a`, because there might be no value at all specified by the client for these.
 > - `QueryFlag "something"` and `MatrixFlag "something"` get turned into arguments of type `Bool`.
 > - `QueryParams "something" a` and `MatrixParams "something" a` get turned into arguments of type `[a]`.
 > - `ReqBody contentTypes a` gets turned into an argument of type `a`.

--- a/tutorial/server.md
+++ b/tutorial/server.md
@@ -146,7 +146,7 @@ You can put this all into a file or just grab [servant's
 repo](http://github.com/haskell-servant/servant) and look at the
 *servant-examples* directory. The code we have just explored is in
 *tutorial/T1.hs*, runnable with
-`dist/build/tutorial/tutorial 2`.
+`dist/build/tutorial/tutorial 1`.
 
 If you run it, you can go to `http://localhost:8081/users` in your browser or
 query it with curl and you see:


### PR DESCRIPTION
Fix incorrect reference to tutorial 2 instead of tutorial 1.