### PR TITLE
Fix T9 example

### DIFF
--- a/tutorial/server.md
+++ b/tutorial/server.md
@@ -1173,7 +1173,7 @@ readerToEither' :: forall a. Reader String a -> EitherT ServantErr IO a
 readerToEither' r = return (runReader r "hi")
 
 readerToEither :: Reader String :~> EitherT ServantErr IO
-readerToEither = Nat . readerToEither'
+readerToEither = Nat readerToEither'
 ```
 
 We can write some simple webservice with the handlers running in `Reader String`.


### PR DESCRIPTION
The example gave this compile error:
```
    Couldn't match type `EitherT ServantErr IO a0'
                  with `forall a. m0 a -> n0 a'
    Expected type: EitherT ServantErr IO a0 -> m0 :~> n0
      Actual type: (forall a. m0 a -> n0 a) -> m0 :~> n0
    In the first argument of `(.)', namely `Nat'
    In the expression: Nat . readerToEither'
```
Looking at the tutorial code showed that the extra `.` was the problem.