### PR TITLE
Update site for new (Raw m a) combinator

### DIFF
--- a/tutorial/api-type.html
+++ b/tutorial/api-type.html
@@ -156,19 +156,20 @@
 </section>
 <section id="interoperability-with-other-wai-applications-raw" class="level3">
 <h3>Interoperability with other WAI <code>Application</code>s: <code>Raw</code></h3>
-<p>Finally, we also include a combinator named <code>Raw</code> that can be used for two reasons:</p>
+<p>Finally, we include a combinator named <code>Raw</code> for handing control to the underlying framework. <code>Raw</code> endpoints trade away the type safety of normal Servant endpoints, in return for direct access to the HTTP request and response. This can be useful for two reasons:</p>
 <ul>
 <li><p>You want to serve static files from a given directory. In that case you can just say:</p>
 <pre class="sourceCode haskell"><code class="sourceCode haskell"><span class="kw">type</span> <span class="dt">UserAPI</span> <span class="fu">=</span> <span class="st">&quot;users&quot;</span> <span class="fu">:&gt;</span> <span class="dt">Get</span> <span class="ch">'[JSON] [User]</span>
                <span class="co">-- a /users endpoint</span>
 
-          <span class="fu">:&lt;|&gt;</span> <span class="dt">Raw</span>
+          <span class="fu">:&lt;|&gt;</span> <span class="dt">Raw IO Application</span>
                <span class="co">-- requests to anything else than /users</span>
                <span class="co">-- go here, where the server will try to</span>
                <span class="co">-- find a file with the right name</span>
                <span class="co">-- at the right path</span></code></pre></li>
 <li><p>You more generally want to plug a <a href="http://hackage.haskell.org/package/wai">WAI <code>Application</code></a> into your webservice. Static file serving is a specific example of that. The API type would look the same as above though. (You can even combine <em>servant</em> with other web frameworks this way!)</p></li>
 </ul>
+<p> <code>Raw</code> takes two type arguments <code>m</code> and <code>a</code> corresponding to the underlying monad your web handler will run in, and the handler's return type. This information is often needed by an API's server but ignored by other inerpretations. As we will see later, it can be useful to have a version of you API that is free of <code>Raw</code> combinators.</p> 
 <div style="text-align: center;">
 <p><a href="../tutorial/server.html">Next page: Serving an API</a></p>
 </div>

--- a/tutorial/docs.html
+++ b/tutorial/docs.html
@@ -172,7 +172,7 @@ docsBS <span class="fu">=</span> encodeUtf8
   <span class="kw">where</span> intro <span class="fu">=</span> <span class="dt">DocIntro</span> <span class="st">&quot;Welcome&quot;</span> [<span class="st">&quot;This is our super webservice's API.&quot;</span>, <span class="st">&quot;Enjoy!&quot;</span>]</code></pre>
 <p><code>docsWithIntros</code> just takes an additional parameter, a list of <code>DocIntro</code>s that must be displayed before any endpoint docs.</p>
 <p>We can now serve the API <em>and</em> the API docs with a simple server.</p>
-<pre class="sourceCode haskell"><code class="sourceCode haskell"><span class="kw">type</span> <span class="dt">DocsAPI</span> <span class="fu">=</span> <span class="dt">T3.API</span> <span class="fu">:&lt;|&gt;</span> <span class="dt">Raw</span>
+<pre class="sourceCode haskell"><code class="sourceCode haskell"><span class="kw">type</span> <span class="dt">DocsAPI</span> <span class="fu">=</span> <span class="dt">T3.API</span> <span class="fu">:&lt;|&gt;</span> <span class="dt">Raw IO Application</span>
 
 <span class="ot">api ::</span> <span class="dt">Proxy</span> <span class="dt">DocsAPI</span>
 api <span class="fu">=</span> <span class="dt">Proxy</span>

--- a/tutorial/javascript.html
+++ b/tutorial/javascript.html
@@ -31,7 +31,7 @@
 <pre class="sourceCode haskell"><code class="sourceCode haskell"><span class="kw">type</span> <span class="dt">API</span> <span class="fu">=</span> <span class="st">&quot;point&quot;</span> <span class="fu">:&gt;</span> <span class="dt">Get</span> <span class="ch">'[JSON] Point</span>
       <span class="fu">:&lt;|&gt;</span> <span class="st">&quot;books&quot;</span> <span class="fu">:&gt;</span> <span class="dt">QueryParam</span> <span class="st">&quot;q&quot;</span> <span class="dt">Text</span> <span class="fu">:&gt;</span> <span class="dt">Get</span> <span class="ch">'[JSON] (Search Book)</span>
 
-<span class="kw">type</span> <span class="dt">API'</span> <span class="fu">=</span> <span class="dt">API</span> <span class="fu">:&lt;|&gt;</span> <span class="dt">Raw</span>
+<span class="kw">type</span> <span class="dt">API'</span> <span class="fu">=</span> <span class="dt">API</span> <span class="fu">:&lt;|&gt;</span> <span class="dt">Raw IO Application</span>
 
 <span class="kw">data</span> <span class="dt">Point</span> <span class="fu">=</span> <span class="dt">Point</span>
   {<span class="ot"> x ::</span> <span class="dt">Double</span>

--- a/tutorial/server.html
+++ b/tutorial/server.html
@@ -539,12 +539,12 @@ myHandler <span class="fu">=</span> return <span class="fu">$</span> addHeader <
 </section>
 <section id="serving-static-files" class="level2">
 <h2>Serving static files</h2>
-<p><em>servant-server</em> also provides a way to just serve the content of a directory under some path in your web API. As mentioned earlier in this document, the <code>Raw</code> combinator can be used in your APIs to mean “plug here any WAI application”. Well, servant-server provides a function to get a file and directory serving WAI application, namely:</p>
+<p><em>servant-server</em> also provides a way to just serve the content of a directory under some path in your web API. As mentioned earlier in this document, the <code>Raw m a</code> combinator can be used in your APIs to mean “plug here any application running in monad <code>m</code> with return value <code>a</code>." Well, servant-server provides a function to get a file and directory serving WAI application, namely:</p>
 <pre class="sourceCode haskell"><code class="sourceCode haskell"><span class="co">-- exported by Servant and Servant.Server</span>
-<span class="ot">serveDirectory ::</span> FilePath <span class="ot">-&gt;</span> <span class="dt">Server</span> <span class="dt">Raw</span></code></pre>
+<span class="ot">serveDirectory ::</span> FilePath <span class="ot">-&gt;</span> <span class="dt">Server</span> <span class="dt">(Raw IO Application)</span></code></pre>
 <p><code>serveDirectory</code>’s argument must be a path to a valid directory. You can see an example below, runnable with <code>dist/build/tutorial/tutorial 6</code> (you <strong>must</strong> run it from within the <em>servant-examples/</em> directory!), which is a webserver that serves the various bits of code covered in this getting-started.</p>
 <p>The API type will be the following.</p>
-<pre class="sourceCode haskell"><code class="sourceCode haskell"><span class="kw">type</span> <span class="dt">API</span> <span class="fu">=</span> <span class="st">&quot;code&quot;</span> <span class="fu">:&gt;</span> <span class="dt">Raw</span></code></pre>
+<pre class="sourceCode haskell"><code class="sourceCode haskell"><span class="kw">type</span> <span class="dt">API</span> <span class="fu">=</span> <span class="st">&quot;code&quot;</span> <span class="fu">:&gt;</span> <span class="dt">Raw IO Application</span></code></pre>
 <p>And the server:</p>
 <pre class="sourceCode haskell"><code class="sourceCode haskell"><span class="ot">api ::</span> <span class="dt">Proxy</span> <span class="dt">API</span>
 api <span class="fu">=</span> <span class="dt">Proxy</span>


### PR DESCRIPTION
These changes to the tutorial incorporate the changes to the `Raw` combinator in @codedmart's pull request #178.

I've posted the html here if you'd like a preview: http://web.mit.edu/greghale/Public/haskell-servant.github.io/