### PR TITLE
Fizruk/announce servant swagger

### DIFF
--- a/check-code/check-code.sh
+++ b/check-code/check-code.sh
@@ -9,3 +9,4 @@ cabal exec -- ghc -Wall -Werror -outputdir build-output ../tutorial/server.lhs -
 cabal exec -- ghc -Wall -Werror -outputdir build-output ../tutorial/client.lhs -O0 -c -fno-warn-missing-methods -fno-warn-name-shadowing
 cabal exec -- ghc -Wall -Werror -outputdir build-output ../tutorial/javascript.lhs -O0 -c -fno-warn-missing-methods
 cabal exec -- ghc -Wall -Werror -ibuild-output -outputdir build-output ../tutorial/docs.lhs -O0 -c -fno-warn-missing-methods
+cabal exec -- runghc -Wall -Werror -fno-warn-missing-methods ../posts/2016-01-21-servant-swagger.lhs -O0 -pgmL markdown-unlit -c

--- a/check-code/tinc.yaml
+++ b/check-code/tinc.yaml
@@ -6,3 +6,6 @@ dependencies:
   - servant-jquery == 0.4.4.6
   - js-jquery == 1.12.0
   - servant-docs == 0.4.4.6
+  - servant-swagger == 0.1.1
+  - swagger2 == 1.2.1
+  - markdown-unlit == 0.4.0

--- a/check-code/tinc.yaml
+++ b/check-code/tinc.yaml
@@ -6,6 +6,6 @@ dependencies:
   - servant-jquery == 0.4.4.6
   - js-jquery == 1.12.0
   - servant-docs == 0.4.4.6
-  - servant-swagger == 0.1.1
-  - swagger2 == 1.2.1
+  - servant-swagger == 1.0.1
+  - swagger2 == 2.0.1
   - markdown-unlit == 0.4.0

--- a/posts/2016-01-21-servant-swagger.lhs
+++ b/posts/2016-01-21-servant-swagger.lhs
@@ -13,7 +13,8 @@ Web API Description languages don't do much in the way of helping you build web
 services in a type-safe way, they are generally very mature, and have some
 amazing tooling. For example, take a look at what `swagger-ui`, a client-side
 HTML, CSS, and JS bundle, does with your `swagger` API description
-[here](http://petstore.swagger.io/?url=https://cdn.rawgit.com/jkarni/a33dd150ac998e586f87/raw/16258a2a9f1784ecde541845ea88c7661f30a588/swagger1.json#/default).
+[here](http://petstore.swagger.io/?url=https://cdn.rawgit.com/jkarni/a33dd150ac998e586f87/raw/f419c59ed4e2b842820d7b2a6e0d2b5e902d986a/swagger.json#/default).
+
 
 
 As you can see, it's a very convenient and approachable way of exploring your
@@ -121,11 +122,13 @@ lenses provided by `swagger2`:
 > swaggerDoc2 = swaggerDoc1
 >   & info.infoTitle .~ "Hackage Users API"
 >   & info.infoDescription ?~ "A demo of servant-swagger"
+>   & host ?~ Host "hackage.haskell.org" Nothing
 
 > main :: IO ()
 > main = BL8.putStr $ encode swaggerDoc2
 
-Which results in [this](https://gist.github.com/jkarni/a33dd150ac998e586f87).
+Which results in
+[this](https://gist.githubusercontent.com/jkarni/a33dd150ac998e586f87/raw/f419c59ed4e2b842820d7b2a6e0d2b5e902d986a/swagger.json).
 
 There's a lot more you can do with both `servant-swagger` and `swagger2` - write
 manual `ToSchema` instances for more detailed information, conveniently add

--- a/posts/2016-01-21-servant-swagger.lhs
+++ b/posts/2016-01-21-servant-swagger.lhs
@@ -58,7 +58,7 @@ First the imports and pragmas (this is a [literate haskell file](https://github.
 >
 > import Control.Lens
 > import Data.Aeson
-> import Data.Aeson.Types (camelTo)
+> import Data.Aeson.Types (camelTo2)
 > import qualified Data.Aeson.Types as JSON
 > import qualified Data.ByteString.Lazy.Char8 as BL8
 > import Data.HashMap.Strict (HashMap)
@@ -127,7 +127,7 @@ Data types:
 `FromJSON` instances:
 
 > modifier :: String -> String
-> modifier = drop 1 . dropWhile (/= '_') . camelTo '_'
+> modifier = drop 1 . dropWhile (/= '_') . camelTo2 '_'
 >
 > prefixOptions :: JSON.Options
 > prefixOptions = JSON.defaultOptions { JSON.fieldLabelModifier = modifier }

--- a/posts/2016-01-21-servant-swagger.lhs
+++ b/posts/2016-01-21-servant-swagger.lhs
@@ -15,6 +15,7 @@ amazing tooling. For example, take a look at what `swagger-ui`, a client-side
 HTML, CSS, and JS bundle, does with your `swagger` API description
 [here](http://petstore.swagger.io/?url=https://cdn.rawgit.com/jkarni/a33dd150ac998e586f87/raw/16258a2a9f1784ecde541845ea88c7661f30a588/swagger1.json#/default).
 
+
 As you can see, it's a very convenient and approachable way of exploring your
 API. In addition to an easily-navigable structure, you can easily build up
 requests and send them to your server, and see its responses.
@@ -40,7 +41,7 @@ libraries, [swagger2](https://hackage.haskell.org/package/swagger2) and
 automate nearly all of that process for `servant` APIs. They use the mechanism
 that guides most of the `servant` ecosystem - interpreters for the type-level
 DSL for APIs that is `servant` - to generate a swagger spec for that API.
-Here's an example - the `user` part of the
+Let's see it's used by; as an example, we're going to take the `user` part of the
 [hackage API](https://hackage.haskell.org/api).
 
 First the imports and pragmas (this is a [literate haskell file](https://github.com/haskell-servant/haskell-servant.github.io/blob/jkarni/announce-servant-swagger/posts/2016-01-21-servant-swagger.lhs)):

--- a/posts/2016-01-21-servant-swagger.lhs
+++ b/posts/2016-01-21-servant-swagger.lhs
@@ -4,19 +4,23 @@ author: David Johnson, Nickolay Kudasov, Julian Arni
 date: 2015-05-25 12:00
 ---
 
-# Swagger
+Swagger
+~~~~~~~
 
 `Servant` is not the first project to provide a unified way of documenting APIs.
 There is `API Blueprint`, `RAML`, `Apiary`, and finally `swagger`. While these
 Web API Description languages don't do much in the way of helping you build web
 services in a type-safe way, they are generally very mature, and have some
 amazing tooling. For example, take a look at what `swagger-ui`, a client-side
-HTML, CSS, and JS bundle, does with your `swagger` API description:
+HTML, CSS, and JS bundle, does with your `swagger` API description
+[here](http://petstore.swagger.io/?url=https://cdn.rawgit.com/jkarni/a33dd150ac998e586f87/raw/16258a2a9f1784ecde541845ea88c7661f30a588/swagger1.json#/default).
 
-...
+As you can see, it's a very convenient and approachable way of exploring your
+API. In addition to an easily-navigable structure, you can easily build up
+requests and send them to your server, and see its responses.
 
-This is a pretty nifty way of documenting your API! But it doesn't end there.
-If you have a `swagger` specification of you API, you can also take advantage
+But it doesn't end there.
+If you have a `swagger` specification of your API, you can also take advantage
 of the large variety of [languages](https://github.com/swagger-api/swagger-codegen/blob/master/README.md#customizing-the-generator) for which you can generate a client
 library automatically. You don't even need to build the Java code - you can
 just use the "Generate Client" button in the beautiful
@@ -27,7 +31,8 @@ that support `swagger`. Obviously, having access to them would be a great boon.
 The problem so far has been that writing and maintaining a `swagger`
 specification, that you are sure matches your service, isn't fun.
 
-# Swagger-servant
+Swagger2 and Servant-swagger
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Thankfully David Johnson and Nickolay Kudasov have written two wonderful Haskell
 libraries, [swagger2](https://hackage.haskell.org/package/swagger2) and
@@ -37,6 +42,20 @@ that guides most of the `servant` ecosystem - interpreters for the type-level
 DSL for APIs that is `servant` - to generate a swagger spec for that API.
 Here's an example - the `user` part of the
 [hackage API](https://hackage.haskell.org/api):
+
+> {-# LANGUAGE TypeOperators #-}
+> {-# LANGUAGE DataKinds #-}
+> {-# LANGUAGE DeriveGeneric #-}
+> {-# LANGUAGE DeriveAnyClass #-}
+> {-# LANGUAGE OverloadedStrings #-}
+> import Control.Lens ((.~), (?~), (&))
+> import Servant.API
+> import Data.Swagger
+> import qualified Data.ByteString.Lazy.Char8 as BL8
+> import Data.Proxy (Proxy(Proxy))
+> import Data.Aeson (encode, ToJSON(..), FromJSON(..))
+> import Servant.Swagger
+> import GHC.Generics (Generic)
 
 > type UserNameAPI
 >        =    Get '[JSON] User
@@ -87,9 +106,8 @@ The next step will traverse the `API`, gathering information about it and
 
 Now we can generate the swagger documentation:
 
-> main = BL8.writeFile "swagger1.json" $ encode swaggerDoc1
-
-You can see the result [here](TODO).
+> genSwaggerDoc1 :: IO ()
+> genSwaggerDoc1 = BL8.putStr $ encode swaggerDoc1
 
 You can attach more information to your `Swagger` doc quite easily, using the
 lenses provided by `swagger2`:
@@ -97,6 +115,10 @@ lenses provided by `swagger2`:
 > swaggerDoc2 :: Swagger
 > swaggerDoc2 = swaggerDoc1
 >   & info.infoTitle .~ "Hackage Users API"
->   & info.infoDescription .~ "A demo of servant-swagger"
+>   & info.infoDescription ?~ "A demo of servant-swagger"
 
-Which results in [this](TODO).
+> main :: IO ()
+> main = BL8.putStr $ encode swaggerDoc2
+
+Which results in [this](https://gist.github.com/jkarni/a33dd150ac998e586f87).
+https://cdn.rawgit.com/jkarni/a33dd150ac998e586f87/raw/16258a2a9f1784ecde541845ea88c7661f30a588/swagger1.json

--- a/posts/2016-01-21-servant-swagger.lhs
+++ b/posts/2016-01-21-servant-swagger.lhs
@@ -5,7 +5,7 @@ date: 2015-05-25 12:00
 ---
 
 Swagger
-~~~~~~~
+--------
 
 `Servant` is not the first project to provide a unified way of documenting APIs.
 There is `API Blueprint`, `RAML`, `Apiary`, and finally `swagger`. While these
@@ -31,8 +31,8 @@ that support `swagger`. Obviously, having access to them would be a great boon.
 The problem so far has been that writing and maintaining a `swagger`
 specification, that you are sure matches your service, isn't fun.
 
-Swagger2 and Servant-swagger
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+swagger2 and servant-swagger
+------------------------------
 
 Thankfully David Johnson and Nickolay Kudasov have written two wonderful Haskell
 libraries, [swagger2](https://hackage.haskell.org/package/swagger2) and
@@ -41,7 +41,9 @@ automate nearly all of that process for `servant` APIs. They use the mechanism
 that guides most of the `servant` ecosystem - interpreters for the type-level
 DSL for APIs that is `servant` - to generate a swagger spec for that API.
 Here's an example - the `user` part of the
-[hackage API](https://hackage.haskell.org/api):
+[hackage API](https://hackage.haskell.org/api).
+
+First the imports and pragmas (this is a [literate haskell file](https://github.com/haskell-servant/haskell-servant.github.io/blob/jkarni/announce-servant-swagger/posts/2016-01-21-servant-swagger.lhs)):
 
 > {-# LANGUAGE TypeOperators #-}
 > {-# LANGUAGE DataKinds #-}
@@ -56,6 +58,8 @@ Here's an example - the `user` part of the
 > import Data.Aeson (encode, ToJSON(..), FromJSON(..))
 > import Servant.Swagger
 > import GHC.Generics (Generic)
+
+The API itself:
 
 > type UserNameAPI
 >        =    Get '[JSON] User
@@ -121,14 +125,13 @@ lenses provided by `swagger2`:
 > main = BL8.putStr $ encode swaggerDoc2
 
 Which results in [this](https://gist.github.com/jkarni/a33dd150ac998e586f87).
-https://cdn.rawgit.com/jkarni/a33dd150ac998e586f87/raw/16258a2a9f1784ecde541845ea88c7661f30a588/swagger1.json
 
-There's a lot more you can do with both `servant-swagger` and `swagger2 - write
+There's a lot more you can do with both `servant-swagger` and `swagger2` - write
 manual `ToSchema` instances for more detailed information, conveniently add
 tags or change responses of parts of your API, use convenient lenses to modify
-any part of your schema. Check of the
-(`servant-swagger`)[https://hackage.haskell.org/package/servant-swagger] and
-(`swagger2`)[https://hackage.haskell.org/package/swagger2] docs for more.
+any part of your schema. Check out the
+[`servant-swagger`](https://hackage.haskell.org/package/servant-swagger) and
+[`swagger2`](https://hackage.haskell.org/package/swagger2) docs for more.
 
 These two new packages vastly expand the landscape of tools within easy reach
 of application developers using `servant`. Time to explore that landscape!

--- a/posts/2016-01-21-servant-swagger.lhs
+++ b/posts/2016-01-21-servant-swagger.lhs
@@ -122,3 +122,13 @@ lenses provided by `swagger2`:
 
 Which results in [this](https://gist.github.com/jkarni/a33dd150ac998e586f87).
 https://cdn.rawgit.com/jkarni/a33dd150ac998e586f87/raw/16258a2a9f1784ecde541845ea88c7661f30a588/swagger1.json
+
+There's a lot more you can do with both `servant-swagger` and `swagger2 - write
+manual `ToSchema` instances for more detailed information, conveniently add
+tags or change responses of parts of your API, use convenient lenses to modify
+any part of your schema. Check of the
+(`servant-swagger`)[https://hackage.haskell.org/package/servant-swagger] and
+(`swagger2`)[https://hackage.haskell.org/package/swagger2] docs for more.
+
+These two new packages vastly expand the landscape of tools within easy reach
+of application developers using `servant`. Time to explore that landscape!

--- a/posts/2016-01-21-servant-swagger.md
+++ b/posts/2016-01-21-servant-swagger.md
@@ -99,4 +99,4 @@ lenses provided by `swagger2`:
 >   & info.infoTitle .~ "Hackage Users API"
 >   & info.infoDescription .~ "A demo of servant-swagger"
 
-Whi results in [this](TODO).
+Which results in [this](TODO).

--- a/posts/2016-01-21-servant-swagger.md
+++ b/posts/2016-01-21-servant-swagger.md
@@ -61,6 +61,9 @@ Here's an example - the `user` part of the
 >
 > data Admin = Admin { adminUser :: User, otherDeets :: String }
 >  deriving (Eq, Show, Read, Generic, FromJSON, ToJSON, ToSchema)
+>
+> api :: Proxy API
+> api = Proxy
 
 (Note that this is almost certainly not a faithful representation, since I've
  had to do some guesswork with respect to requests and response bodies.)
@@ -68,4 +71,18 @@ Here's an example - the `user` part of the
 So far this is what you would usually have when working with `servant`. The
 only new thing you might notice is the `ToSchema` class in the `deriving`
 clauses. This will give us a generically-derived `swagger` schema (which is
-quite similar to, but not entirely the same as, JSON Schema).
+quite similar to, but not entirely the same as, JSON Schema). Part of the
+`swagger2` package, it can be quite useful in its own right if you want to e.g.
+respond with a schema in case of bad request bodies, or OPTIONS requests.
+
+The next step will traverse the `API`, gathering information about it and
+`swagger2` schemas to generate a `Swagger` object:
+
+> swaggerDoc :: Swagger
+> swaggerDoc = toSwagger api
+
+(If you're keeping tabs, so far the amount of extra work we've done compared to
+ what we would have to do anyway for a `servant` server or client is these two
+ lines, plus two "ToSchema" strings.)
+
+

--- a/posts/2016-01-21-servant-swagger.md
+++ b/posts/2016-01-21-servant-swagger.md
@@ -1,0 +1,35 @@
+---
+title: servant paper submitted to WGP 2015
+author: David Johnson, Nickolay Kudasov, Julian Arni
+date: 2015-05-25 12:00
+---
+
+# Swagger
+
+`Servant` is not the first project to provide a unified way of documenting APIs.
+There is `API Blueprint`, `RAML`, `Apiary`, and finally `swagger`. While these
+Web API Description languages don't do much in the way of helping you build web
+services in a type-safe way, they are generally very mature, and have some
+amazing tooling. For example, take a look at what `swagger-ui`, a client-side
+HTML, CSS, and JS bundle, does with your `swagger` API description:
+
+...
+
+This is a pretty nifty way of documenting your API! But it doesn't end there.
+If you have a `swagger` specification of you API, you can also take advantage
+of the large variety of [languages](https://github.com/swagger-api/swagger-codegen/blob/master/README.md#customizing-the-generator) for which you can generate a client
+library automatically. You don't even need to build the Java code - you can
+just use the "Generate Client" button in the beautiful
+[swagger editor](http://editor.swagger.io/#/).
+
+There are a wide array of other [tools](http://swagger.io/open-source-integrations/)
+that support `swagger`. Obviously, having access to them would be a great boon.
+The problem so far has been that writing and maintaining a `swagger`
+specification, that you are sure matches your service, isn't fun.
+
+# Swagger-servant
+
+Thankfully David Johnson and Nickolay Kudasanov have written two wonderful Haskell
+libraries, [swagger2](https://hackage.haskell.org/package/swagger2) and
+[servant-swagger](https://hackage.haskell.org/package/servant-swagger), that
+automate nearly all of that process for `servant` APIs.

--- a/posts/2016-01-21-servant-swagger.md
+++ b/posts/2016-01-21-servant-swagger.md
@@ -76,13 +76,27 @@ quite similar to, but not entirely the same as, JSON Schema). Part of the
 respond with a schema in case of bad request bodies, or OPTIONS requests.
 
 The next step will traverse the `API`, gathering information about it and
-`swagger2` schemas to generate a `Swagger` object:
+`swagger2` schemas to generate a `Swagger` value:
 
-> swaggerDoc :: Swagger
-> swaggerDoc = toSwagger api
+> swaggerDoc1 :: Swagger
+> swaggerDoc1 = toSwagger api
 
 (If you're keeping tabs, so far the amount of extra work we've done compared to
  what we would have to do anyway for a `servant` server or client is these two
  lines, plus two "ToSchema" strings.)
 
+Now we can generate the swagger documentation:
 
+> main = BL8.writeFile "swagger1.json" $ encode swaggerDoc1
+
+You can see the result [here](TODO).
+
+You can attach more information to your `Swagger` doc quite easily, using the
+lenses provided by `swagger2`:
+
+> swaggerDoc2 :: Swagger
+> swaggerDoc2 = swaggerDoc1
+>   & info.infoTitle .~ "Hackage Users API"
+>   & info.infoDescription .~ "A demo of servant-swagger"
+
+Whi results in [this](TODO).

--- a/posts/2016-01-21-servant-swagger.md
+++ b/posts/2016-01-21-servant-swagger.md
@@ -1,5 +1,5 @@
 ---
-title: servant paper submitted to WGP 2015
+title: Announcing servant-swagger and swagger2
 author: David Johnson, Nickolay Kudasov, Julian Arni
 date: 2015-05-25 12:00
 ---
@@ -29,7 +29,13 @@ specification, that you are sure matches your service, isn't fun.
 
 # Swagger-servant
 
-Thankfully David Johnson and Nickolay Kudasanov have written two wonderful Haskell
+Thankfully David Johnson and Nickolay Kudasov have written two wonderful Haskell
 libraries, [swagger2](https://hackage.haskell.org/package/swagger2) and
 [servant-swagger](https://hackage.haskell.org/package/servant-swagger), that
-automate nearly all of that process for `servant` APIs.
+automate nearly all of that process for `servant` APIs. They use the mechanism
+that guides most of the `servant` ecosystem - interpreters for the type-level
+DSL for APIs that is `servant` - to generate a swagger spec for that API.
+Here's an example:
+
+>
+gg


### PR DESCRIPTION
This is an update @jkarni's post with GitHub Gists API for demo.
Compared to Hackage API this:
- enables "Try it out!" button in Swagger UI;
- demonstrates the use of `SchemaOptions` and how it mimics `aeson`'s `Options`;
- provides only `GET` requests.