### PR TITLE
fix deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,4 @@
-REPO_URL="https://github.com/haskell-servant/haskell-servant.github.io"
+REPO_URL="git@github.com:haskell-servant/haskell-servant.github.io"
 SERVANT_WWW="$HOME/.servant-www"
 SITE="$PWD/_site"
 CURRDIR="$PWD"
@@ -6,12 +6,15 @@ BIN="dist/build/site/site"
 COMMIT=`git rev-parse HEAD`
 MSG="Built from $COMMIT"
 
+set -o errexit
+
 if [ ! -d $SERVANT_WWW ]; then
 	git clone $REPO_URL $HOME/.servant-www
 	echo "Created directory $SERVANT_WWW"
 fi
 
 cd $SERVANT_WWW
+git checkout master
 git rm -r ./*
 cp -R $SITE/* ./ 
 git add ./**


### PR DESCRIPTION
Now it doesn't get confused by `master` not being the default branch.
Also, it uses the ssh github url. This means that you need to have ssh
access to the repo and that you won't be asked for your username and
password on every deploy. You have to delete ~/.servant-www once for
that to work.

@alpmestan, @jkarni: Can one of you take a look, please?