### PR TITLE
Change character to string

### DIFF
--- a/posts/2018-07-12-servant-dsl-typelevel.md
+++ b/posts/2018-07-12-servant-dsl-typelevel.md
@@ -400,7 +400,7 @@ type Link = [String]
 
 -- @renderLink ["hello", "world"] == "/hello/world"@
 renderLink :: Link -> String
-renderLink xs = '/' : intercalate '/' xs
+renderLink xs = '/' : intercalate "/" xs
 
 class HasLink endpoint where
   -- return the path components


### PR DESCRIPTION
Intercalate's type signature is
```haskell
intercalate :: [a] -> [[a]] -> [a] 
```
so
```haskell
intercalate '/' xs
```
should be
```haskell
intercalate "/" xs
```